### PR TITLE
Add delayed job enqueue trace

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -617,7 +617,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 
 ### DelayedJob
 
-The DelayedJob integration uses lifecycle hooks to trace the job executions.
+The DelayedJob integration uses lifecycle hooks to trace the job executions and enqueues.
 
 You can enable it through `Datadog.configure`:
 
@@ -635,6 +635,7 @@ Where `options` is an optional `Hash` that accepts the following parameters:
 | --- | ----------- | ------- |
 | `analytics_enabled` | Enable analytics for spans produced by this integration. `true` for on, `nil` to defer to global setting, `false` for off. | `false` |
 | `service_name` | Service name used for `DelayedJob` instrumentation | `'delayed_job'` |
+| `client_service_name` | Service name used for client-side `DelayedJob` instrumentation | `'delayed_job-client'` |
 
 ### Elasticsearch
 

--- a/lib/ddtrace/contrib/delayed_job/configuration/settings.rb
+++ b/lib/ddtrace/contrib/delayed_job/configuration/settings.rb
@@ -23,6 +23,7 @@ module Datadog
           end
 
           option :service_name, default: Ext::SERVICE_NAME
+          option :client_service_name, default: Ext::CLIENT_SERVICE_NAME
         end
       end
     end

--- a/lib/ddtrace/contrib/delayed_job/ext.rb
+++ b/lib/ddtrace/contrib/delayed_job/ext.rb
@@ -10,7 +10,9 @@ module Datadog
         ENV_ANALYTICS_SAMPLE_RATE = 'DD_TRACE_DELAYED_JOB_ANALYTICS_SAMPLE_RATE'.freeze
         ENV_ANALYTICS_SAMPLE_RATE_OLD = 'DD_DELAYED_JOB_ANALYTICS_SAMPLE_RATE'.freeze
         SERVICE_NAME = 'delayed_job'.freeze
+        CLIENT_SERVICE_NAME = 'delayed_job-client'.freeze
         SPAN_JOB = 'delayed_job'.freeze
+        SPAN_ENQUEUE = 'delayed_job.enqueue'.freeze
         TAG_ATTEMPTS = 'delayed_job.attempts'.freeze
         TAG_ID = 'delayed_job.id'.freeze
         TAG_PRIORITY = 'delayed_job.priority'.freeze

--- a/lib/ddtrace/contrib/delayed_job/plugin.rb
+++ b/lib/ddtrace/contrib/delayed_job/plugin.rb
@@ -7,18 +7,10 @@ module Datadog
     module DelayedJob
       # DelayedJob plugin that instruments invoke_job hook
       class Plugin < Delayed::Plugin
-        def self.instrument(job, &block)
+        def self.instrument_invoke(job, &block)
           return block.call(job) unless tracer && tracer.enabled
 
-          # When DelayedJob is used through ActiveJob, we need to parse the payload differentely
-          # to get the actual job name
-          job_name = if job.payload_object.respond_to?(:job_data)
-                       job.payload_object.job_data['job_class']
-                     else
-                       job.name
-                     end
-
-          tracer.trace(Ext::SPAN_JOB, service: configuration[:service_name], resource: job_name) do |span|
+          tracer.trace(Ext::SPAN_JOB, service: configuration[:service_name], resource: job_name(job)) do |span|
             # Set analytics sample rate
             if Contrib::Analytics.enabled?(configuration[:analytics_enabled])
               Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])
@@ -31,6 +23,26 @@ module Datadog
             span.set_tag(Ext::TAG_QUEUE, job.queue) if job.queue
             span.set_tag(Ext::TAG_PRIORITY, job.priority)
             span.set_tag(Ext::TAG_ATTEMPTS, job.attempts)
+            span.span_type = Datadog::Ext::AppTypes::WORKER
+
+            yield job
+          end
+        end
+
+        def self.instrument_enqueue(job, &block)
+          return block.call(job) unless tracer && tracer.enabled
+
+          tracer.trace(Ext::SPAN_ENQUEUE, service: configuration[:client_service_name], resource: job_name(job)) do |span|
+            # Set analytics sample rate
+            if Contrib::Analytics.enabled?(configuration[:analytics_enabled])
+              Contrib::Analytics.set_sample_rate(span, configuration[:analytics_sample_rate])
+            end
+
+            # Measure service stats
+            Contrib::Analytics.set_measured(span)
+
+            span.set_tag(Ext::TAG_QUEUE, job.queue) if job.queue
+            span.set_tag(Ext::TAG_PRIORITY, job.priority)
             span.span_type = Datadog::Ext::AppTypes::WORKER
 
             yield job
@@ -51,8 +63,17 @@ module Datadog
           configuration[:tracer]
         end
 
+        def self.job_name(job)
+          # When DelayedJob is used through ActiveJob, we need to parse the payload differentely
+          # to get the actual job name
+          return job.payload_object.job_data['job_class'] if job.payload_object.respond_to?(:job_data)
+
+          job.name
+        end
+
         callbacks do |lifecycle|
-          lifecycle.around(:invoke_job, &method(:instrument))
+          lifecycle.around(:invoke_job, &method(:instrument_invoke))
+          lifecycle.around(:enqueue, &method(:instrument_enqueue))
           lifecycle.around(:execute, &method(:flush))
         end
       end


### PR DESCRIPTION
It would be great to monitor `delayed_job` enqueues in case of any errors of latency related to those events.


Example usage:
```ruby
c.use :delayed_job, {
  service_name: nil,
  client_service_name: "#{app_name}-delayed_job-client",
  analytics_enabled: true,
}
```